### PR TITLE
MNT: updating links to sludge package

### DIFF
--- a/docs/source/tutorials/accessing_packages.ipynb
+++ b/docs/source/tutorials/accessing_packages.ipynb
@@ -1075,7 +1075,7 @@
     "# Get all reviewed packages\n",
     "reviewed_packages = [\n",
     "    Package(eP.requester, id=EAWAG_BBD_URL),\n",
-    "    Package(eP.requester, id=\"https://envipath.org/package/7932e576-03c7-4106-819d-fe80dc605b8a\"), # EAWAG-SLUDGE\n",
+    "    Package(eP.requester, id=\"https://envipath.org/package/521c547a-fd2a-491c-ad5b-7eaa1577fb65\"), # EAWAG-SLUDGE\n",
     "    Package(eP.requester, id=\"https://envipath.org/package/5882df9c-dae1-4d80-a40e-db4724271456\") # EAWAG-SOIL\n",
     "]\n",
     "\n",

--- a/docs/source/tutorials/download_additional_information_data.ipynb
+++ b/docs/source/tutorials/download_additional_information_data.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "INSTANCE_HOST = \"https://envipath.org/\"\n",
-    "EAWAG_SLUDGE_DATA_PACKAGE = \"https://envipath.org/package/7932e576-03c7-4106-819d-fe80dc605b8a\"\n",
+    "EAWAG_SLUDGE_DATA_PACKAGE = \"https://envipath.org/package/521c547a-fd2a-491c-ad5b-7eaa1577fb65\"\n",
     "\n",
     "eP = enviPath(INSTANCE_HOST)\n",
     "pkg = Package(eP.requester, id=EAWAG_SLUDGE_DATA_PACKAGE)"

--- a/docs/source/tutorials/download_pathway_SBML.ipynb
+++ b/docs/source/tutorials/download_pathway_SBML.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this tutorial we will show how can to export an enviPath Pathway to SBML in a few lines of code. The pathway that we will download is the [Deprenyl](https://envipath.org/package/7932e576-03c7-4106-819d-fe80dc605b8a/pathway/b21b1d65-e0d1-4060-b890-45bf3713924a) pathway from EAWAG-SLUDGE.\n",
+    "In this tutorial we will show how can to export an enviPath Pathway to SBML in a few lines of code. The pathway that we will download is the [Deprenyl](https://envipath.org/package/521c547a-fd2a-491c-ad5b-7eaa1577fb65/pathway/c9434148-85ea-4f30-b8aa-afe790923cf3) pathway from EAWAG-SLUDGE.\n",
     "\n",
     "For this tutorial we will import [libsbml](https://synonym.caltech.edu/software/libsbml/5.18.0/docs/formatted/python-api/), a Python API that facilitates the generation of SBML documents from various data formats.\n",
     "\n",
@@ -33,8 +33,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[33mWARNING: Skipping enviPath_python as it is not installed.\u001b[0m\u001b[33m\n",
-      "\u001b[0m"
+      "\u001B[33mWARNING: Skipping enviPath_python as it is not installed.\u001B[0m\u001B[33m\n",
+      "\u001B[0m"
      ]
     }
    ],
@@ -46,7 +46,7 @@
     "\n",
     "HOST_INSTANCE = \"https://envipath.org/\"\n",
     "eP = enviPath(HOST_INSTANCE)\n",
-    "pwid = HOST_INSTANCE + 'package/7932e576-03c7-4106-819d-fe80dc605b8a/pathway/b21b1d65-e0d1-4060-b890-45bf3713924a' # Deprenyl sludge\n",
+    "pwid = HOST_INSTANCE + 'package/521c547a-fd2a-491c-ad5b-7eaa1577fb65/pathway/c9434148-85ea-4f30-b8aa-afe790923cf3' # Deprenyl sludge\n",
     "package = 'SLUDGE'\n",
     "pathway = Pathway(eP.requester, id=pwid)"
    ]


### PR DESCRIPTION
The links to the sludge package (2023, https://envipath.org/package/7932e576-03c7-4106-819d-fe80dc605b8a) were replaced in the docs/tutorials with the new sludge package (2025, https://envipath.org/package/521c547a-fd2a-491c-ad5b-7eaa1577fb65) thas has been re-merged and curated after the merge_package function was fixed by Albert, allowing to copy alternatife structures.