### PR TITLE
Patched enviPath-python to be compatible with enviPath2.0

### DIFF
--- a/enviPath_python/enviPath.py
+++ b/enviPath_python/enviPath.py
@@ -30,7 +30,7 @@ class enviPath(object):
     Object representing enviPath functionality.
     """
 
-    def __init__(self, base_url, proxies=None, adapter=None):
+    def __init__(self, base_url, proxies=None, adapter=None, new_api=False):
         """
         Constructor with instance specification.
 
@@ -41,6 +41,7 @@ class enviPath(object):
         """
         self.BASE_URL = base_url if base_url.endswith('/') else base_url + '/'
         self.requester = enviPathRequester(self, proxies, adapter)
+        self.new_api = new_api
 
     def get_base_url(self) -> str:
         """
@@ -411,6 +412,20 @@ class enviPathRequester(object):
             default_headers = copy.deepcopy(default_headers)
             default_headers.update(**kwargs['headers'])
             del kwargs['headers']
+
+        # For enviPy we have to channel the request to certain endpoints e.g.
+        # "api/legacy/," therefore, we can't use the plain Object IDs of the individual
+        # objects. Check if the given BASE_URL (e.g. https://envipath.org/api/legacy/) is part of
+        # the Object ID. If not, replace and execute the request.
+        if self.eP.BASE_URL not in url:
+            from urllib.parse import urlparse
+            parsed = urlparse(self.eP.BASE_URL)
+            url = url.replace(f"{parsed.scheme}://{parsed.netloc}/", self.eP.BASE_URL)
+
+            # RelativeReasonings are now called Model
+            if 'relative-reasoning' in url:
+                url = url.replace("relative-reasoning", "model")
+
         try:
             response = self.session.request(method, url, params=params, data=payload, headers=default_headers, **kwargs)
         except ConnectionError:

--- a/enviPath_python/objects.py
+++ b/enviPath_python/objects.py
@@ -175,8 +175,9 @@ class enviPathObject(ABC):
             self.__delattr__(key)
 
     def refresh(self):
-        # TODO clear internal cache and fetch json again
-        pass
+        self.loaded = False
+        self.get_name()
+        return self
 
 
 class ReviewableEnviPathObject(enviPathObject, ABC):
@@ -2139,6 +2140,9 @@ class Setting(enviPathObject):
                evaluation_type: EvaluationType = None, min_carbon: int = None,
                terminal_compounds: List[Compound] = None):
 
+        if ep.new_api:
+            raise ValueError("This endpoint is not available in the new API")
+
         payload = {
             'packages[]': [p.get_id() for p in packages]
         }
@@ -2234,6 +2238,9 @@ class NormalizationRule(ReviewableEnviPathObject):
 
     @staticmethod
     def create(setting: 'Setting', smirks: str, name: str = None, description: str = None):
+        if setting.requester.eP.new_api:
+            raise ValueError("This endpoint is not available in the new API")
+
         if not smirks:
             raise ValueError("SMIRKS not set!")
 


### PR DESCRIPTION
The enviPath object can now be initialized with a `base_url` other than `https://envipath.org/`.
This change supports the upcoming enviPath 2.0 API, which introduces a dedicated endpoint (`/api/legacy/`) and no longer allows direct retrieval of objects using only their plain id.

For example, consider the following package:

```
pack = Package(
    eP.requester, 
    id="https://envipath.org/package/32de3cf4-e3e6-4168-956e-32fa5ddb0ce1"
)
```

With this update, all API calls will automatically replace `https://envipath.org/` with the value specified in `eP.base_url`.