### PR TITLE
[Feature] Session Retry, Group is now kwarg when creating packages

### DIFF
--- a/enviPath_python/enviPath.py
+++ b/enviPath_python/enviPath.py
@@ -340,7 +340,6 @@ class enviPathRequester(object):
                 total=3,
                 backoff_factor=1,
                 status_forcelist=[500, 502, 503, 504],
-                allowed_methods=False,
             )
             adapter = HTTPAdapter(max_retries=retry)
 

--- a/enviPath_python/enviPath.py
+++ b/enviPath_python/enviPath.py
@@ -15,12 +15,13 @@
 # DEALINGS IN THE SOFTWARE.
 import copy
 from collections.abc import Iterable
-from typing import Union, List
+from typing import List
 
 import requests
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import *
+from urllib3.util.retry import Retry
 
 from enviPath_python.objects import *
 
@@ -288,7 +289,7 @@ class enviPath(object):
         """
         return self.requester.get_objects(self.BASE_URL, Endpoint.GROUP)
 
-    def create_package(self, group: 'Group', name: str = None, description: str = None) -> Package:
+    def create_package(self, group: 'Group' = None, name: str = None, description: str = None) -> Package:
         """
         Function that creates an enviPath package
 
@@ -301,7 +302,7 @@ class enviPath(object):
         :return: The created package
         :rtype: enviPath_python.objects.Package
         """
-        return Package.create(self, group, name=name, description=description)
+        return Package.create(self, group=group, name=name, description=description)
 
 
 class enviPathRequester(object):
@@ -335,7 +336,13 @@ class enviPathRequester(object):
         """
 
         if adapter is None:
-            adapter = HTTPAdapter()
+            retry = Retry(
+                total=3,
+                backoff_factor=1,
+                status_forcelist=[500, 502, 503, 504],
+                allowed_methods=False,
+            )
+            adapter = HTTPAdapter(max_retries=retry)
 
         self.eP = eP
         self.session = Session()

--- a/enviPath_python/objects.py
+++ b/enviPath_python/objects.py
@@ -507,7 +507,7 @@ class Package(enviPathObject):
 
     # TODO typing for ep or being consistent with eP.requester...
     @staticmethod
-    def create(ep, group: 'Group', name: str = None, description: str = None) -> 'Package':
+    def create(ep, group: 'Group' = None, name: str = None, description: str = None) -> 'Package':
         """
         Creates the package
 
@@ -519,7 +519,11 @@ class Package(enviPathObject):
         """
         # TODO add type hint for ep and get rid of cyclic import
         package_payload = dict()
-        package_payload['groupURI'] = group.get_id()
+
+        # Legacy system expects a group
+        if ep.new_api is None or not ep.new_api:
+            package_payload['groupURI'] = group.get_id()
+
         if name:
             package_payload['packageName'] = name
         if description:


### PR DESCRIPTION
To test whether the retry was triggered enable logging via:

```
import logging
logging.basicConfig(level=logging.INFO)
logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
logging.getLogger("urllib3.util.retry").setLevel(logging.INFO)
```

`WARNING:urllib3.connectionpool:Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7c163bce9850>: Failed to establish a new connection: [Errno 111] Connection refused')': ...
`